### PR TITLE
Fix for cucumber feature files compare 

### DIFF
--- a/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/GenerateCucumber.mwe2
+++ b/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/GenerateCucumber.mwe2
@@ -121,9 +121,9 @@ Workflow {
                 // fragment = refactoring.RefactorElementNameFragment {}
     
                 // provides a compare view
-                // fragment = compare.CompareFragment {
-                //    fileExtensions = file.extensions
-                // }
+                fragment = compare.CompareFragment {
+                    fileExtensions = file.extensions
+                }
     
                 // Serializer 2.0
                 // fragment = serializer.SerializerFragment {}


### PR DESCRIPTION
Eclipse compare for cucumber feature files was not working. After looking at the code I found out that the Compare Fragment inclusion code on GenerateCucumber.mwe2 was commented out. Therefore uncommenting it solved the issue and compare works now.
