### PR TITLE
Eclipse 2020 (1)

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Natural</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/org.agileware.natural.common/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse BDD Editors Common Library
 Bundle-SymbolicName: org.agileware.natural.common
-Bundle-Version: 1.2.1.qualifier
+Bundle-Version: 1.2.2.qualifier
 Bundle-Activator: org.agileware.natural.common.Activator
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.eclipse.jface.text;bundle-version="3.10.0";visibility:=reexport,

--- a/org.agileware.natural.common/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.common/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: Eclipse BDD Editors Common Library
 Bundle-SymbolicName: org.agileware.natural.common
 Bundle-Version: 1.2.2.qualifier
 Bundle-Activator: org.agileware.natural.common.Activator
-Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
- org.eclipse.jface.text;bundle-version="3.10.0";visibility:=reexport,
- org.eclipse.ui;bundle-version="3.107.0",
- org.eclipse.ui.ide;bundle-version="3.11.0",
- org.eclipse.jdt.ui;bundle-version="3.11.2",
- org.eclipse.jdt.core;bundle-version="3.11.2",
- org.eclipse.core.resources;bundle-version="3.10.1",
- com.google.guava;bundle-version="15.0.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.17.100";visibility:=reexport,
+ org.eclipse.jface.text;bundle-version="3.16.200";visibility:=reexport,
+ org.eclipse.ui;bundle-version="3.116.0",
+ org.eclipse.ui.ide;bundle-version="3.17.0",
+ org.eclipse.jdt.ui;bundle-version="3.21.0",
+ org.eclipse.jdt.core;bundle-version="3.21.0",
+ org.eclipse.core.resources;bundle-version="3.13.700",
+ com.google.guava;bundle-version="27.1.0",
  com.google.inject;bundle-version="3.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.agileware.natural.common/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse BDD Editors Common Library
 Bundle-SymbolicName: org.agileware.natural.common
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Activator: org.agileware.natural.common.Activator
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.eclipse.jface.text;bundle-version="3.10.0";visibility:=reexport,

--- a/org.agileware.natural.cucumber.feature/feature.xml
+++ b/org.agileware.natural.cucumber.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.agileware.natural.cucumber.feature"
       label="Cucumber Editor"
-      version="0.7.6.qualifier"
+      version="0.7.7.qualifier"
       provider-name="Roberto Lo Giacco">
 
    <description url="https://github.com/rlogiacco/bdd-eclipse/wiki">

--- a/org.agileware.natural.cucumber.feature/feature.xml
+++ b/org.agileware.natural.cucumber.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.agileware.natural.cucumber.feature"
       label="Cucumber Editor"
-      version="0.7.7.qualifier"
+      version="0.7.8.qualifier"
       provider-name="Roberto Lo Giacco">
 
    <description url="https://github.com/rlogiacco/bdd-eclipse/wiki">

--- a/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.rlogiacco.eclipse.cucumber.tests
 Bundle-Vendor: My Company
-Bundle-Version: 1.3.6.qualifier
+Bundle-Version: 1.3.7.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.cucumber,

--- a/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
@@ -7,12 +7,12 @@ Bundle-SymbolicName: org.agileware.natural.cucumber.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.cucumber,
  org.agileware.natural.cucumber.ui,
- org.eclipse.core.runtime;bundle-version="3.11.1",
- org.eclipse.xtext;bundle-version="2.9.1",
- org.eclipse.xtext.junit4;bundle-version="2.9.1",
- org.eclipse.ui.workbench;bundle-version="3.107.1";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.9.1",
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.eclipse.core.runtime;bundle-version="3.17.100",
+ org.eclipse.xtext;bundle-version="2.21.0",
+ org.eclipse.xtext.junit4;bundle-version="2.21.0",
+ org.eclipse.ui.workbench;bundle-version="3.118.0";resolution:=optional,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.21.0",
+ org.objectweb.asm;bundle-version="[7.2.0,8.0.0)";resolution:=optional
 Import-Package: org.apache.log4j,
  org.apache.commons.logging,
  org.junit.runner;version="4.5.0",

--- a/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.rlogiacco.eclipse.cucumber.tests
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.0
+Bundle-Version: 1.3.6.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.cucumber,

--- a/org.agileware.natural.cucumber.ui/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.cucumber.ui
 Bundle-Vendor: Roberto Lo Giacco
-Bundle-Version: 1.3.5.qualifier
+Bundle-Version: 1.3.7.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.ui;bundle-version="2.9.1",

--- a/org.agileware.natural.cucumber.ui/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber.ui/META-INF/MANIFEST.MF
@@ -5,18 +5,18 @@ Bundle-Vendor: Roberto Lo Giacco
 Bundle-Version: 1.3.7.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.ui;bundle-version="2.9.1",
- org.eclipse.ui.editors;bundle-version="3.9.0",
- org.eclipse.ui.ide;bundle-version="3.11.0",
- org.eclipse.xtext.ui.shared;bundle-version="2.9.1",
- org.eclipse.ui;bundle-version="3.107.0",
- org.eclipse.xtext.builder;bundle-version="2.9.1",
+Require-Bundle: org.eclipse.xtext.ui;bundle-version="2.21.0",
+ org.eclipse.ui.editors;bundle-version="3.13.100",
+ org.eclipse.ui.ide;bundle-version="3.17.0",
+ org.eclipse.xtext.ui.shared;bundle-version="2.21.0",
+ org.eclipse.ui;bundle-version="3.116.0",
+ org.eclipse.xtext.builder;bundle-version="2.21.0",
  org.antlr.runtime;bundle-version="3.2.0",
- org.eclipse.xtext.common.types.ui;bundle-version="2.9.1",
- org.eclipse.xtext.ui.codetemplates.ui;bundle-version="2.9.1",
- org.eclipse.compare;bundle-version="3.5.600",
- org.eclipse.jdt.ui;bundle-version="3.11.2",
- org.eclipse.jdt.core;bundle-version="3.11.2",
+ org.eclipse.xtext.common.types.ui;bundle-version="2.21.0",
+ org.eclipse.xtext.ui.codetemplates.ui;bundle-version="2.21.0",
+ org.eclipse.compare;bundle-version="3.7.900",
+ org.eclipse.jdt.ui;bundle-version="3.21.0",
+ org.eclipse.jdt.core;bundle-version="3.21.0",
  org.agileware.natural.cucumber
 Import-Package: org.apache.commons.logging,
  org.apache.log4j

--- a/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.cucumber
 Bundle-Vendor: Roberto Lo Giacco
-Bundle-Version: 1.3.6.qualifier
+Bundle-Version: 1.3.7.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,

--- a/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
@@ -5,23 +5,23 @@ Bundle-Vendor: Roberto Lo Giacco
 Bundle-Version: 1.3.7.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,
- org.eclipse.xtext.xbase;bundle-version="2.9.1";resolution:=optional;visibility:=reexport,
+Require-Bundle: org.eclipse.xtext;bundle-version="2.21.0";visibility:=reexport,
+ org.eclipse.xtext.xbase;bundle-version="2.21.0";resolution:=optional;visibility:=reexport,
  org.apache.log4j;visibility:=reexport,
  org.apache.commons.logging;resolution:=optional;visibility:=reexport,
- org.eclipse.xtext.generator;bundle-version="2.9.1";resolution:=optional,
- org.eclipse.emf.codegen.ecore;bundle-version="2.11.1";resolution:=optional,
- org.eclipse.emf.mwe.utils;bundle-version="1.3.13";resolution:=optional,
- org.eclipse.emf.mwe2.launch;bundle-version="2.8.3";resolution:=optional,
- org.eclipse.xtext.util;bundle-version="2.9.1",
- org.eclipse.emf.ecore;bundle-version="2.11.2",
- org.eclipse.emf.common;bundle-version="2.11.1",
+ org.eclipse.xtext.generator;bundle-version="2.21.0";resolution:=optional,
+ org.eclipse.emf.codegen.ecore;bundle-version="2.21.0";resolution:=optional,
+ org.eclipse.emf.mwe.utils;bundle-version="1.5.2";resolution:=optional,
+ org.eclipse.emf.mwe2.launch;bundle-version="2.11.2";resolution:=optional,
+ org.eclipse.xtext.util;bundle-version="2.21.0",
+ org.eclipse.emf.ecore;bundle-version="2.21.0",
+ org.eclipse.emf.common;bundle-version="2.18.0",
  org.antlr.runtime;bundle-version="3.2.0",
- org.eclipse.xtext.common.types;bundle-version="2.9.1",
- org.eclipse.jdt.core;bundle-version="3.11.2",
+ org.eclipse.xtext.common.types;bundle-version="2.21.0",
+ org.eclipse.jdt.core;bundle-version="3.21.0",
  org.agileware.natural.common;visibility:=reexport,
- org.eclipse.xtext.xbase.lib;bundle-version="2.9.1",
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.eclipse.xtext.xbase.lib;bundle-version="2.21.0",
+ org.objectweb.asm;bundle-version="[7.2.0,8.0.0)";resolution:=optional
 Import-Package: org.apache.commons.logging,
  org.apache.log4j,
  org.eclipse.xtext.xbase.lib

--- a/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.cucumber/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.cucumber
 Bundle-Vendor: Roberto Lo Giacco
-Bundle-Version: 1.3.5.qualifier
+Bundle-Version: 1.3.6.qualifier
 Bundle-SymbolicName: org.agileware.natural.cucumber;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,

--- a/org.agileware.natural.jbehave.feature/feature.xml
+++ b/org.agileware.natural.jbehave.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.agileware.natural.jbehave.feature"
       label="JBehave Editor"
-      version="0.3.1.qualifier"
+      version="0.3.2.qualifier"
       provider-name="Roberto Lo Giacco">
 
    <description url="https://github.com/rlogiacco/bdd-eclipse/wiki">

--- a/org.agileware.natural.jbehave.feature/feature.xml
+++ b/org.agileware.natural.jbehave.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.agileware.natural.jbehave.feature"
       label="JBehave Editor"
-      version="0.3.0.qualifier"
+      version="0.3.1.qualifier"
       provider-name="Roberto Lo Giacco">
 
    <description url="https://github.com/rlogiacco/bdd-eclipse/wiki">

--- a/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave.tests
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave,

--- a/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
@@ -7,12 +7,12 @@ Bundle-SymbolicName: org.agileware.natural.jbehave.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave,
  org.agileware.natural.jbehave.ui,
- org.eclipse.core.runtime;bundle-version="3.11.1",
- org.eclipse.xtext;bundle-version="2.9.1",
- org.eclipse.xtext.junit4;bundle-version="2.9.1",
- org.eclipse.ui.workbench;bundle-version="3.107.1";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.9.1",
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.eclipse.core.runtime;bundle-version="3.17.100",
+ org.eclipse.xtext;bundle-version="2.21.0",
+ org.eclipse.xtext.junit4;bundle-version="2.21.0",
+ org.eclipse.ui.workbench;bundle-version="3.118.0";resolution:=optional,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.21.0",
+ org.objectweb.asm;bundle-version="7.2.0";resolution:=optional
 Import-Package: org.apache.log4j,
  org.apache.commons.logging,
  org.junit.runner;version="4.5.0",

--- a/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave.tests
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.1.qualifier
+Bundle-Version: 1.0.2.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave,

--- a/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave.ui
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave;visibility:=reexport,

--- a/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
@@ -6,16 +6,16 @@ Bundle-Version: 1.0.2.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave;visibility:=reexport,
- org.eclipse.xtext.ui;bundle-version="2.9.1",
- org.eclipse.ui.editors;bundle-version="3.9.0",
- org.eclipse.ui.ide;bundle-version="3.11.0",
- org.eclipse.xtext.ui.shared;bundle-version="2.9.1",
- org.eclipse.ui;bundle-version="3.107.0",
- org.eclipse.xtext.builder;bundle-version="2.9.1",
+ org.eclipse.xtext.ui;bundle-version="2.21.0",
+ org.eclipse.ui.editors;bundle-version="3.13.100",
+ org.eclipse.ui.ide;bundle-version="3.17.0",
+ org.eclipse.xtext.ui.shared;bundle-version="2.21.0",
+ org.eclipse.ui;bundle-version="3.116.0",
+ org.eclipse.xtext.builder;bundle-version="2.21.0",
  org.antlr.runtime;bundle-version="3.2.0",
- org.eclipse.xtext.common.types.ui;bundle-version="2.9.1",
- org.eclipse.xtext.ui.codetemplates.ui;bundle-version="2.9.1",
- org.eclipse.compare;bundle-version="3.5.600"
+ org.eclipse.xtext.common.types.ui;bundle-version="2.21.0",
+ org.eclipse.xtext.ui.codetemplates.ui;bundle-version="2.21.0",
+ org.eclipse.compare;bundle-version="3.7.900"
 Import-Package: org.apache.log4j,
  org.apache.commons.logging
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave.ui
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.1.qualifier
+Bundle-Version: 1.0.2.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.agileware.natural.jbehave;visibility:=reexport,

--- a/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave
 Bundle-Vendor: Roberto Lo Giacco
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,

--- a/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.agileware.natural.jbehave
 Bundle-Vendor: Roberto Lo Giacco
-Bundle-Version: 1.0.1.qualifier
+Bundle-Version: 1.0.2.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,

--- a/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
+++ b/org.agileware.natural.jbehave/META-INF/MANIFEST.MF
@@ -5,21 +5,21 @@ Bundle-Vendor: Roberto Lo Giacco
 Bundle-Version: 1.0.2.qualifier
 Bundle-SymbolicName: org.agileware.natural.jbehave; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext;bundle-version="2.9.1";visibility:=reexport,
- org.eclipse.xtext.xbase;bundle-version="2.9.1";resolution:=optional;visibility:=reexport,
+Require-Bundle: org.eclipse.xtext;bundle-version="2.21.0";visibility:=reexport,
+ org.eclipse.xtext.xbase;bundle-version="2.21.0";resolution:=optional;visibility:=reexport,
  org.apache.log4j;visibility:=reexport,
  org.apache.commons.logging;resolution:=optional;visibility:=reexport,
- org.eclipse.xtext.generator;bundle-version="2.9.1";resolution:=optional,
- org.eclipse.emf.codegen.ecore;bundle-version="2.11.1";resolution:=optional,
- org.eclipse.emf.mwe.utils;bundle-version="1.3.13";resolution:=optional,
- org.eclipse.emf.mwe2.launch;bundle-version="2.8.3";resolution:=optional,
- org.eclipse.xtext.util;bundle-version="2.9.1",
- org.eclipse.emf.ecore;bundle-version="2.11.2",
- org.eclipse.emf.common;bundle-version="2.11.1",
+ org.eclipse.xtext.generator;bundle-version="2.21.0";resolution:=optional,
+ org.eclipse.emf.codegen.ecore;bundle-version="2.21.0";resolution:=optional,
+ org.eclipse.emf.mwe.utils;bundle-version="1.5.2";resolution:=optional,
+ org.eclipse.emf.mwe2.launch;bundle-version="2.11.2";resolution:=optional,
+ org.eclipse.xtext.util;bundle-version="2.21.0",
+ org.eclipse.emf.ecore;bundle-version="2.21.0",
+ org.eclipse.emf.common;bundle-version="2.18.0",
  org.antlr.runtime;bundle-version="3.2.0",
- org.eclipse.xtext.common.types;bundle-version="2.9.1",
- org.eclipse.xtext.xbase.lib;bundle-version="2.9.1",
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.eclipse.xtext.common.types;bundle-version="2.21.0",
+ org.eclipse.xtext.xbase.lib;bundle-version="2.21.0",
+ org.objectweb.asm;bundle-version="7.2.0";resolution:=optional
 Import-Package: org.apache.commons.logging,
  org.apache.log4j,
  org.eclipse.xtext.xbase.lib


### PR DESCRIPTION
Depends On: https://github.com/rlogiacco/Natural/pull/70

This is a good starting point for any new Eclipse 2020 functionality. It is identical to the Mars update, with minimum dependency versions set to 2020-03 release.