### PR TITLE
37: Tagged Scenario Outline breaks indentation of subsequent Scenarios and Scenario Outlines

### DIFF
--- a/org.agileware.natural.cucumber.ui/src/org/agileware/natural/cucumber/ui/labeling/CucumberLabelProvider.java
+++ b/org.agileware.natural.cucumber.ui/src/org/agileware/natural/cucumber/ui/labeling/CucumberLabelProvider.java
@@ -5,7 +5,7 @@ package org.agileware.natural.cucumber.ui.labeling;
 
 import org.agileware.natural.cucumber.cucumber.Background;
 import org.agileware.natural.cucumber.cucumber.DocString;
-import org.agileware.natural.cucumber.cucumber.Examples;
+import org.agileware.natural.cucumber.cucumber.Example;
 import org.agileware.natural.cucumber.cucumber.Feature;
 import org.agileware.natural.cucumber.cucumber.Scenario;
 import org.agileware.natural.cucumber.cucumber.ScenarioOutline;
@@ -87,11 +87,11 @@ public class CucumberLabelProvider extends DefaultEObjectLabelProvider {
 		return "code.gif";
 	}
 
-	String text(Examples ele) {
+	String text(Example ele) {
 		return ele.getTitle().isEmpty() ? "Examples" : ele.getTitle();
 	}
 
-	String image(Examples ele) {
+	String image(Example ele) {
 		return "example.gif";
 	}
 

--- a/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/Cucumber.xtext
+++ b/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/Cucumber.xtext
@@ -30,7 +30,7 @@ ScenarioOutline:
 	title=Title? EOL+
 	narrative=Narrative?
 	steps+=Step+
-	examples=Examples;
+	example+=Example+;
 	
 Step:
 	STEP_KEYWORD
@@ -39,7 +39,8 @@ Step:
 	code=DocString?
 	tables+=Table*;
 
-Examples:
+Example:
+	tags+=Tag*
 	'Examples:' 
 	title=Title? EOL+
 	narrative=Narrative?

--- a/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/formatting/CucumberFormatter.java
+++ b/org.agileware.natural.cucumber/src/org/agileware/natural/cucumber/formatting/CucumberFormatter.java
@@ -27,8 +27,8 @@ public class CucumberFormatter extends AbstractDeclarativeFormatter {
 		c.setIndentationDecrement().after(g.getNarrativeRule());
 		c.setIndentationIncrement().before(g.getStepRule());
 		c.setIndentationDecrement().after(g.getStepRule());
-		c.setIndentationIncrement().before(g.getExamplesRule());
-		c.setIndentationDecrement().after(g.getExamplesRule());
+		c.setIndentationIncrement().before(g.getExampleRule());
+		c.setIndentationDecrement().after(g.getExampleRule());
 		c.setIndentationIncrement().before(g.getTableRule());
 		c.setIndentationDecrement().after(g.getTableRule());
 		c.setIndentationIncrement().before(g.getDocStringRule());


### PR DESCRIPTION
Task-Url: https://github.com/rlogiacco/Natural/issues/37

	Changed cardinality to `examples+=Example+` and added Tag support